### PR TITLE
feat: Show destination URL below AKA link in Markdown output for easy search

### DIFF
--- a/src/aka.exporter/Program.cs
+++ b/src/aka.exporter/Program.cs
@@ -105,13 +105,13 @@ class Program
         await using (StreamWriter file = new(markdownFileName))
         {
             // Create a beautiful Markdown table
-            await file.WriteLineAsync("| AKA Link | Title | HTTP Result | HTTP Status Line |");
+            await file.WriteLineAsync("| AKA Link <br/> Destination URL | Title | HTTP Result | HTTP Status Line |");
             await file.WriteLineAsync("| --- | --- | --- | --- |");
 
             foreach (var (rowKey, akaLink, url, clicks, title, httpResult, httpStatusLine) in rows)
             {
                 string formattedAkaLink = EscapeMarkdownValue(akaLink);
-                string formattedUrl = url;
+                string formattedUrl = EscapeMarkdownValue(url);
                 string formattedTitle = EscapeMarkdownValue(title);
                 
                 // Coloring the HTTP result based on its value
@@ -122,8 +122,9 @@ class Program
                     >= 400 => $"![](https://img.shields.io/badge/{httpResult}-error-red)",
                     _ => $"![](https://img.shields.io/badge/{httpResult}-unknown-gray)"
                 };
+
                 await file.WriteLineAsync(
-                    $"| [{formattedAkaLink}]({formattedUrl}) | {formattedTitle} | {httpResultBadge} | {EscapeMarkdownValue(httpStatusLine)} |");
+                    $"| [{formattedAkaLink}](<{url}>)<br/><sub>`{formattedUrl}`</sub> | {formattedTitle} | {httpResultBadge} | {EscapeMarkdownValue(httpStatusLine)} |");
             }
         }
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?  

- Feature  

## Description
Update `Program.cs` to show the destination URL directly below the AKA link in Markdown export for easier search and readability. 

## Before/After

**Before**

| AKA Link | Title | HTTP Result | HTTP Status Line |
| --- | --- | --- | --- |
| [https://aka.platform.uno/app-wizard](https://new.platform.uno) | Live App Wizard | ![](https://img.shields.io/badge/200-success-green) | OK |

**After**

| AKA Link <br/> Destination URL | Title | HTTP Result | HTTP Status Line |
| --- | --- | --- | --- |
| [https://aka.platform.uno/app-wizard](<https://new.platform.uno>)<br/><sub>`https://new.platform.uno`</sub> | Live App Wizard | ![](https://img.shields.io/badge/200-success-green) | OK |
